### PR TITLE
Add Lint job to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,3 +41,22 @@ jobs:
 
       - name: Check formatting
         run: test -z "$(go fmt ./...)"
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.25.1"
+
+      - name: Install Staticcheck
+        run: go install honnef.co/go/tools/cmd/staticcheck@latest
+
+      - name: Run Staticcheck
+        run: staticcheck ./...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Check formatting
         run: test -z "$(go fmt ./...)"
 
-  lint:
+    lint:
     name: Lint
     runs-on: ubuntu-latest
 
@@ -60,3 +60,4 @@ jobs:
 
       - name: Run Staticcheck
         run: staticcheck ./...
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Check formatting
         run: test -z "$(go fmt ./...)"
 
-    lint:
+  lint:
     name: Lint
     runs-on: ubuntu-latest
 
@@ -56,8 +56,9 @@ jobs:
           go-version: "1.25.1"
 
       - name: Install Staticcheck
-        run: go install honnef.co/go/tools/cmd/staticcheck@latest
+        run: |
+          go install honnef.co/go/tools/cmd/staticcheck@latest
+          echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
 
       - name: Run Staticcheck
         run: staticcheck ./...
-

--- a/main.go
+++ b/main.go
@@ -96,7 +96,3 @@ func main() {
 	log.Printf("Serving on port: %s\n", port)
 	log.Fatal(srv.ListenAndServe())
 }
-func unused() {
-	// this function does nothing
-	// and is called nowhere
-}

--- a/main.go
+++ b/main.go
@@ -24,8 +24,10 @@ type apiConfig struct {
 //go:embed static/*
 var staticFiles embed.FS
 
-func main() {
 
+
+
+func main() {
 	err := godotenv.Load(".env")
 	if err != nil {
 		log.Printf("warning: assuming default configuration. .env unreadable: %v", err)

--- a/main.go
+++ b/main.go
@@ -24,9 +24,6 @@ type apiConfig struct {
 //go:embed static/*
 var staticFiles embed.FS
 
-
-
-
 func main() {
 	err := godotenv.Load(".env")
 	if err != nil {
@@ -98,4 +95,8 @@ func main() {
 
 	log.Printf("Serving on port: %s\n", port)
 	log.Fatal(srv.ListenAndServe())
+}
+func unused() {
+	// this function does nothing
+	// and is called nowhere
 }


### PR DESCRIPTION

- Runs staticcheck on the Go codebase
- Helps catch unused functions, dead code, and common mistakes
- Complements the existing Style and Tests jobs


